### PR TITLE
Remove metadata bar from drill-to-detail modal

### DIFF
--- a/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
+++ b/superset-frontend/src/components/Chart/DrillDetail/DrillDetailPane.tsx
@@ -312,7 +312,7 @@ export default function DrillDetailPane({
 
   return (
     <>
-      {!bootstrapping && metadataBar}
+      {/* {!bootstrapping && metadataBar} */}
       {!bootstrapping && (
         <TableControls
           filters={filters}


### PR DESCRIPTION
- Commented out metadata bar rendering in DrillDetailPane component
- This removes the red-boxed section showing table name, creator, and last modified info
- Modal now shows only table controls and data table